### PR TITLE
add default empty string for description

### DIFF
--- a/src/lib/supabase/settings.ts
+++ b/src/lib/supabase/settings.ts
@@ -3,6 +3,7 @@ import { supabase } from "$lib/supabaseClient"; // Your Supabase client initiali
 export const defaultSettings = {
 	logo: "/logo.png",
 	title: "",
+	description: "",
 };
 
 let cachedSettings = null;


### PR DESCRIPTION
so that link previews don't have an "undefined" in the description