### PR TITLE
add scrollable problem editor latex preview

### DIFF
--- a/src/lib/components/Problem.svelte
+++ b/src/lib/components/Problem.svelte
@@ -121,7 +121,7 @@
 	{/if}
 	<div class="flex">
 		<div
-			style="border: 2px solid black;width: {widthPara}%;margin: 10px;padding: 10px; resize: both; overflow: scroll;"
+			style="border: 2px solid black;width: {widthPara}%;margin: 10px;padding: 10px; resize: vertical; overflow: scroll; height: 60vh;"
 		>
 			<p class="header">Problem</p>
 			<p id="problem-render">{@html latexes.problem}</p>

--- a/src/lib/components/Problem.svelte
+++ b/src/lib/components/Problem.svelte
@@ -121,7 +121,7 @@
 	{/if}
 	<div class="flex">
 		<div
-			style="border: 2px solid black;width: {widthPara}%;margin: 10px;padding: 10px;"
+			style="border: 2px solid black;width: {widthPara}%;margin: 10px;padding: 10px; resize: both; overflow: scroll;"
 		>
 			<p class="header">Problem</p>
 			<p id="problem-render">{@html latexes.problem}</p>

--- a/src/lib/components/ProblemEditor.svelte
+++ b/src/lib/components/ProblemEditor.svelte
@@ -198,8 +198,8 @@
 {#if loading}
 	<p>Loading problem editor...</p>
 {:else}
-	<div class="row editorContainer" style="grid-template-columns: 70% 30%;">
-		<div class="col">
+	<div class="row editorContainer">
+		<div class="col" style="overflow: auto; resize: horizontal; width: 60vw;">
 			<Form class="editorForm">
 				<FormGroup style="display: flex; align-items: end;">
 					<MultiSelect
@@ -417,6 +417,12 @@
 {/if}
 
 <style>
+	/* Resizable grid columns. See https://stackoverflow.com/a/53731196 */
+	.editorContainer {
+		grid-template: 1fr 
+		/ min-content 1fr;
+	}
+	
 	:global(.editorForm) {
 		padding: 20px;
 	}

--- a/src/lib/components/images/ImageManager.svelte
+++ b/src/lib/components/images/ImageManager.svelte
@@ -265,6 +265,11 @@
 
 	.listing-container {
 		margin-top: 5px;
+		overflow-y: scroll;
+		resize: vertical;
+		height: 20vh;
+		padding: 5px;
+		border: thin solid #00000030;
 	}
 
 	.listing-item {


### PR DESCRIPTION
Unfortunately, since the rendered latex seems to be absolutely positioned, the size of the whole page's scrollbar doesn't decrease to match the decreased size of the latex preview. 

Also adds horizontal adjustable sizing of the problem editor vs problem preview

https://github.com/user-attachments/assets/1bcbf959-5006-45ce-a18a-b24f26d7e35f

https://github.com/user-attachments/assets/1b7b741d-ebcd-4056-8319-cb27d7ebd187