### PR TITLE
fix: rm dup trycatch => surfaces save draft error

### DIFF
--- a/src/lib/components/ProblemEditor.svelte
+++ b/src/lib/components/ProblemEditor.svelte
@@ -187,6 +187,7 @@
 				throw new Error("Not all the required fields have been filled out");
 			}
 		} catch (error) {
+			submittedText = error.message;
 			handleError(error);
 			toast.error(error.message);
 		}

--- a/src/routes/problems/[id]/edit/+page.svelte
+++ b/src/routes/problems/[id]/edit/+page.svelte
@@ -60,7 +60,6 @@
 	};
 
 	async function submitProblem(payload) {
-		try {
 			const { topics, problem_files, ...payloadNoTopics } = payload;
 			const data = await editProblem(payloadNoTopics, Number($page.params.id));
 			console.log("DATA", data);
@@ -83,10 +82,6 @@
 
 			dirty = false;
 			toast.success("Successfully updated problem.");
-		} catch (error) {
-			handleError(error);
-			toast.error(error.message);
-		}
 		/** ENDPOINT NEEDS TO BE FIXED
 		try {
 			// Update discord webhook.

--- a/src/routes/problems/new/+page.svelte
+++ b/src/routes/problems/new/+page.svelte
@@ -29,43 +29,38 @@
 		authorName = await getAuthorName((await getThisUser()).id);
 
 		console.log(payload);
-		try {
-			if (authorName === "") {
-				throw new Error("Author name is not defined");
-			}
-			if (payload.topics.length == 0) {
-				throw new Error("Must specify at least one topic for this problem");
-			} else {
-				const data = await createProblem(payload);
+		if (authorName === "") {
+			throw new Error("Author name is not defined");
+		}
+		if (payload.topics.length == 0) {
+			throw new Error("Must specify at least one topic for this problem");
+		} else {
+			const data = await createProblem(payload);
 
-				let imageDownloadResult = await ImageBucket.downloadLatexImages(
-					payload.problem_latex
+			let imageDownloadResult = await ImageBucket.downloadLatexImages(
+				payload.problem_latex
+			);
+			let imageName = "";
+			if (imageDownloadResult.images.length > 0) {
+				imageName = await ImageBucket.getImageURL(
+					imageDownloadResult.images[0].name
 				);
-				let imageName = "";
+			} else {
+				imageDownloadResult = await ImageBucket.downloadLatexImages(
+					payload.solution_latex
+				);
 				if (imageDownloadResult.images.length > 0) {
 					imageName = await ImageBucket.getImageURL(
 						imageDownloadResult.images[0].name
 					);
-				} else {
-					imageDownloadResult = await ImageBucket.downloadLatexImages(
-						payload.solution_latex
-					);
-					if (imageDownloadResult.images.length > 0) {
-						imageName = await ImageBucket.getImageURL(
-							imageDownloadResult.images[0].name
-						);
-					}
 				}
-
-				openModal = true;
-				problem_id = data.id;
-				//window.location.replace(`/problems/${problemId}`);
 			}
-			dirty = false;
-		} catch (error) {
-			handleError(error);
-			toast.error(error.message);
+
+			openModal = true;
+			problem_id = data.id;
+			//window.location.replace(`/problems/${problemId}`);
 		}
+		dirty = false;
 	}
 </script>
 


### PR DESCRIPTION
removes duplicate try catch blocks so that an error in saving a draft problem is actually shown as an error (instead of showing up as "Draft Saved")